### PR TITLE
remove basic auth variable and disable username and password.

### DIFF
--- a/postman/ehrBase Local Docker.postman_environment.json
+++ b/postman/ehrBase Local Docker.postman_environment.json
@@ -5,12 +5,12 @@
 		{
 			"key": "Username",
 			"value": "ehrbase-user",
-			"enabled": true
+			"enabled": false
 		},
 		{
 			"key": "Password",
 			"value": "SuperSecretPassword",
-			"enabled": true
+			"enabled": false
 		},
 		{
 			"key": "subjectId",
@@ -46,11 +46,6 @@
 			"key": "committerName",
 			"value": "Dr Franke",
 			"enabled": true
-		},
-		{
-			"key": "Authorization",
-			"value": "Basic Z3Vlc3Q6Z3Vlc3Q=",
-			"enabled": false
 		},
 		{
 			"key": "skipDeletes",


### PR DESCRIPTION
The basic auth variable get's flagged by postman as a data breach which removes the workspace from being discoverable. ehrbase (in it's docker_compose) by default no longer needs auth. So I think disabling the variables is a little less confusing to new users.